### PR TITLE
Chore: updated .gitignore to exclude local env specific file/folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# DB files
+/prisma/dev.db
+/prisma/dev.db-journal
+
+# Migration files
+/prisma/migrations/
+/prisma/schema.prisma
+/prisma/migrations/migration_lock.toml


### PR DESCRIPTION
Just wanted to clean up my local git changes, so I could keep track of changes I'm making locally, and not accidentally commit something I'm not supposed to.

Only other local env exception if ProblemsQueue.tsx. We probably want to detect an environment variable to avoid running the problematic line of code instead of having people comment it out locally.