### PR TITLE
fix: allow tab buttons and action buttons to wrap on smaller screens

### DIFF
--- a/src/components/app/Problem.tsx
+++ b/src/components/app/Problem.tsx
@@ -319,7 +319,7 @@ const Problem = ({ problem, contentActive, setContentActive, editorContent, setE
         >
           <div className="h-full border-r border-[#3A4253] bg-base_100">
             <div className="p-4 border-b border-[#3A4253]">
-              <div className="flex gap-2 items-center">
+              <div className="flex flex-wrap gap-2 items-center mb-2">
                 <TabButton 
                   active={contentActive === 'question'} 
                   label="Description" 
@@ -343,7 +343,6 @@ const Problem = ({ problem, contentActive, setContentActive, editorContent, setE
                 <div className="h-8 w-px bg-[#3A4253] mx-3"></div>
                 
                                  {/* Action buttons */}
-                 <div className="flex items-center gap-1">
                    <ActionButton 
                      onClick={() => setIsEditModalOpen(true)}
                      icon="edit"


### PR DESCRIPTION
## Description
<!-- What does this PR add or fix? -->
Fixes layout overflow in the problem view's top tab/action section. Ensures the action buttons (Edit, Stats, Run on Leetcode) and tabs (Description, Notes, Solution) wrap gracefully into a new line on smaller screen widths.

Closes #21 

---

### Checklist
- [x] I've read **CONTRIBUTING.md**
- [x] Lint & tests pass
- [x] Docs updated if needed
- [x] Added reviewers/assignees
- [x] My code follows project style

---

### Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Docs update
- [ ] 🧹 Chore / refactor
