### PR TITLE
feat: add skip button to move stuck problems to end of queue by updating due date to latest +1min; allows returning later

### DIFF
--- a/src/components/app/ProblemsQueue.tsx
+++ b/src/components/app/ProblemsQueue.tsx
@@ -414,6 +414,42 @@ const ProblemsQueue = ({ problems, userSettings, refetchProblems }: {problems:an
       queryClient.invalidateQueries(['collectionDetails']); // for updating ProblemList
     }
 
+    // Skip function to move current problem to end of queue
+    const skipProblem = async () => {
+        setIsLoading(true);
+        
+        // Get the latest due date among current problems and add 1 minute to it
+        const latestDueDate = dueProblems.reduce((latest: Date, problem: any) => {
+            const problemDueDate = new Date(problem.dueDate);
+            return problemDueDate > latest ? problemDueDate : latest;
+        }, new Date());
+        
+        // Set the skipped problem's due date to 1 minute after the latest due date
+        const newDueDate = new Date(latestDueDate.getTime() + 60000); // 1 minute later
+        
+        const updates = {
+            dueDate: newDueDate,
+        };
+        
+        updateProblemMutation.mutate({ problemId: dueProblems[0].id, updates }, {
+            onSuccess: async () => {
+                // Remove the skipped problem from the front and add it to the end
+                const skippedProblem = { ...dueProblems[0], dueDate: newDueDate };
+                const remainingProblems = dueProblems.slice(1);
+                setDueProblems([...remainingProblems, skippedProblem]);
+                
+                await refetchProblems();
+                setIsLoading(false);
+                setContent('question');
+                setEditorContent('');
+            },
+            onError: (error) => {
+                console.error('Error skipping problem:', error);
+                setIsLoading(false);
+            },
+        });
+    };
+
     // handles the logic of what happens to the problem depeneding on the feedback button pressed 
     const Algorithm = async(buttonValue:any) => {
         console.log(`Button clicked: ${buttonValue}`); 
@@ -1053,6 +1089,23 @@ const ProblemsQueue = ({ problems, userSettings, refetchProblems }: {problems:an
             },
           }}
         />
+
+        {/* Skip button - positioned to the left of AI Help */}
+        {dueProblems.length > 0 && (
+          <button 
+            onClick={skipProblem}
+            className="fixed bottom-6 right-36 flex items-center px-4 py-3 bg-gradient-to-r from-[#f59e0b] to-[#f97316] hover:from-[#d97706] hover:to-[#ea580c] text-white rounded-full transition-all duration-200 z-10 group"
+            style={{ 
+              boxShadow: '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'
+            }}
+            onMouseOver={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.3), 0 4px 6px -4px rgba(249, 115, 22, 0.3)'}
+            onMouseOut={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'}
+          >
+            <span className="material-icons mr-2" style={{ fontSize: '20px' }}>skip_next</span>
+            <span className="font-medium">Skip</span>
+            <div className="absolute inset-0 rounded-full bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
+          </button>
+        )}
 
         {/* Floating AI Help button with matching gradient and shadow */}
         <button 

--- a/src/components/app/ProblemsQueue.tsx
+++ b/src/components/app/ProblemsQueue.tsx
@@ -1092,19 +1092,31 @@ const ProblemsQueue = ({ problems, userSettings, refetchProblems }: {problems:an
 
         {/* Skip button - positioned to the left of AI Help */}
         {dueProblems.length > 0 && (
-          <button 
-            onClick={skipProblem}
-            className="fixed bottom-6 right-36 flex items-center px-4 py-3 bg-gradient-to-r from-[#f59e0b] to-[#f97316] hover:from-[#d97706] hover:to-[#ea580c] text-white rounded-full transition-all duration-200 z-10 group"
-            style={{ 
-              boxShadow: '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'
-            }}
-            onMouseOver={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.3), 0 4px 6px -4px rgba(249, 115, 22, 0.3)'}
-            onMouseOut={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'}
-          >
-            <span className="material-icons mr-2" style={{ fontSize: '20px' }}>skip_next</span>
-            <span className="font-medium">Skip</span>
-            <div className="absolute inset-0 rounded-full bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
-          </button>
+          <div className="fixed bottom-6 right-36 z-10 group">
+            <button 
+              onClick={skipProblem}
+              className="flex items-center px-4 py-3 bg-gradient-to-r from-[#f59e0b] to-[#f97316] hover:from-[#d97706] hover:to-[#ea580c] text-white rounded-full transition-all duration-200"
+              style={{ 
+                boxShadow: '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'
+              }}
+              onMouseOver={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.3), 0 4px 6px -4px rgba(249, 115, 22, 0.3)'}
+              onMouseOut={(e) => e.currentTarget.style.boxShadow = '0 10px 15px -3px rgba(249, 115, 22, 0.2), 0 4px 6px -4px rgba(249, 115, 22, 0.2)'}
+            >
+              <span className="material-icons mr-2" style={{ fontSize: '20px' }}>skip_next</span>
+              <span className="font-medium">Skip</span>
+              <div className="absolute inset-0 rounded-full bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
+            </button>
+            
+            {/* Tooltip */}
+            <div className="absolute -top-16 left-1/2 transform -translate-x-1/2 z-50 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+              <div className="px-3 py-2 bg-[#2A303C] border border-[#3A4150] rounded-lg shadow-xl w-56">
+                <div className="text-xs text-[#B0B7C3] leading-relaxed">
+                  Skip this problem for now, it will reappear later
+                </div>
+                <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-[#3A4150]"></div>
+              </div>
+            </div>
+          </div>
         )}
 
         {/* Floating AI Help button with matching gradient and shadow */}


### PR DESCRIPTION

## Description
<!-- What does this PR add or fix? -->

Adds a "Skip" button to the Problem Queue that allows users to temporarily move stuck problems to the end of their current study session.

**Problem**: Users in Study Mode must solve problems in exact order - no way to skip difficult problems and return later.

**Solution**: 
- Added orange "Skip" button positioned left of AI Help button
- Skipped problems get moved to end of queue (due date set to latest + 1 minute)
- Allows users to maintain flow by solving easier problems first, then returning to difficult ones
- Maintains spaced repetition benefits while giving users more control

Closes #25

---

### Checklist
- [x] I've read **CONTRIBUTING.md**
- [x] Lint & tests pass
- [x] Docs updated if needed
- [x] Added reviewers/assignees
- [x] My code follows project style

### Screenshots / Logs (optional)
<!-- Drag-n-drop images or paste terminal output -->

https://github.com/user-attachments/assets/5ea34335-ca30-417f-8e21-508ea6292d57



---

### Type of Change
- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Docs update
- [ ] 🧹 Chore / refactor