### PR TITLE
Add stopwatch timer to problem-solving top bar

### DIFF
--- a/src/components/app/Problem.tsx
+++ b/src/components/app/Problem.tsx
@@ -20,6 +20,7 @@ import Toast from './Toast';
 import Badge from '@/components/ui/Badge';
 import { Whiteboard, DrawingElement } from './WhiteBoard';
 import { ArrowLeft, Edit3, BarChart2, ExternalLink, ClipboardPen, NotepadText, Lightbulb, BotMessageSquare, PenSquare, MoreHorizontal } from "lucide-react";
+import Stopwatch from './Stopwatch';
 const sanitizeCodeBlocks = (html: string) => {
   const div = document.createElement('div');
   div.innerHTML = html;
@@ -447,13 +448,14 @@ const Problem = ({ problem, contentActive, setContentActive, editorContent, setE
           </div>
         </div>
         <div className="flex items-center text-xs text-white" style={{ color: '#FFFFFF' }}>
+          <Stopwatch resetKey={localProblem.id} />
           <div className="relative mr-2">
             <div className="w-2.5 h-2.5 bg-review rounded-full"></div>
             <div className="absolute inset-0 w-2.5 h-2.5 bg-[#00FF00] rounded-full opacity-70 animate-pulse" style={{ filter: "blur(1px)" }}></div>
           </div>
-          <a 
-            href="/changelog" 
-            target="_blank" 
+          <a
+            href="/changelog"
+            target="_blank"
             rel="noopener noreferrer"
             className="hover:text-link transition-colors duration-200 cursor-pointer"
           >

--- a/src/components/app/ProblemsQueue.tsx
+++ b/src/components/app/ProblemsQueue.tsx
@@ -22,6 +22,7 @@ import Badge from '@/components/ui/Badge';
 import Joyride, { CallBackProps, STATUS, Step } from 'react-joyride';
 import { Whiteboard, DrawingElement } from './WhiteBoard';
 import { ClipboardPen, NotepadText, Lightbulb, BotMessageSquare, PenSquare, Edit3, BarChart2, ExternalLink, MoreHorizontal } from "lucide-react";
+import Stopwatch from './Stopwatch';
 
 // If there's ever a <code> nested within a <pre>, it breaks everything, so we need to check for this and remove it 
 const sanitizeCodeBlocks = (html: string) => {
@@ -1010,9 +1011,10 @@ const ProblemsQueue = ({ problems, userSettings, refetchProblems }: {problems:an
           
           {/* Status indicator stays on the right */}
           <div className="flex items-center text-xs text-[#B0B7C3]">
+            <Stopwatch resetKey={dueProblems[0]?.id ?? 'empty'} />
             <div className="relative mr-2">
               <div className="w-2.5 h-2.5 bg-review rounded-full"></div>
-              <div 
+              <div
                 className="absolute inset-0 w-2.5 h-2.5 bg-[#00FF00] rounded-full opacity-70"
                 style={{
                   animation: "breathe 3s ease-in-out infinite",

--- a/src/components/app/Stopwatch.tsx
+++ b/src/components/app/Stopwatch.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { Timer, Play, Pause, RotateCcw } from 'lucide-react';
+
+interface StopwatchProps {
+  resetKey: string | number;
+}
+
+export default function Stopwatch({ resetKey }: StopwatchProps) {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const startInterval = useCallback(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      setElapsedSeconds((s) => s + 1);
+    }, 1000);
+  }, []);
+
+  const stopInterval = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Reset when resetKey changes
+  useEffect(() => {
+    setElapsedSeconds(0);
+    setIsRunning(false);
+    stopInterval();
+  }, [resetKey, stopInterval]);
+
+  // Sync interval with isRunning state
+  useEffect(() => {
+    if (isRunning) {
+      startInterval();
+    } else {
+      stopInterval();
+    }
+    return stopInterval;
+  }, [isRunning, startInterval, stopInterval]);
+
+  // Pause when tab is hidden, resume when visible
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stopInterval();
+      } else if (isRunning) {
+        startInterval();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [isRunning, startInterval, stopInterval]);
+
+  const formatTime = (totalSeconds: number) => {
+    const hrs = Math.floor(totalSeconds / 3600);
+    const mins = Math.floor((totalSeconds % 3600) / 60);
+    const secs = totalSeconds % 60;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return hrs > 0
+      ? `${pad(hrs)}:${pad(mins)}:${pad(secs)}`
+      : `${pad(mins)}:${pad(secs)}`;
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 mr-3 px-3 py-1 rounded-md border bg-[#3A4253] border-[#3A4253]">
+      <Timer size={14} className="text-[#B0B7C3]" />
+      <span
+        className="text-white text-xs font-mono"
+        style={{ fontVariantNumeric: 'tabular-nums', minWidth: '3.2em' }}
+      >
+        {formatTime(elapsedSeconds)}
+      </span>
+      <button
+        onClick={() => setIsRunning((r) => !r)}
+        className="p-1 rounded hover:bg-[#2A303C]/50 transition-colors text-[#B0B7C3]"
+        title={isRunning ? 'Pause' : 'Resume'}
+      >
+        {isRunning ? <Pause size={12} /> : <Play size={12} />}
+      </button>
+      <button
+        onClick={() => {
+          setElapsedSeconds(0);
+          setIsRunning(true);
+        }}
+        className="p-1 rounded hover:bg-[#2A303C]/50 transition-colors text-[#B0B7C3]"
+        title="Reset"
+      >
+        <RotateCcw size={12} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `Stopwatch` component to the top bar in both `Problem` and `ProblemsQueue` views
- Timer starts paused at `00:00`; user manually starts it with the play button
- Resets automatically when the active problem changes
- Pauses when the browser tab is hidden, resumes on return
- Styled to match existing difficulty/type badge pills (`bg-[#3A4253]`, rounded, bordered)
- Uses tabular-nums + monospace font to prevent layout jitter
- No new dependencies — uses existing `lucide-react` icons (`Timer`, `Play`, `Pause`, `RotateCcw`)
<img width="726" height="451" alt="Screenshot 2026-03-02 at 1 03 41 PM" src="https://github.com/user-attachments/assets/6b3dffd1-85ae-4a09-91f3-f01f4711f831" />

Closes #48